### PR TITLE
Fix issue 5

### DIFF
--- a/bin/jsfiddle-downloader.js
+++ b/bin/jsfiddle-downloader.js
@@ -217,53 +217,51 @@ function loadDataFromUrl(url){
             var amount_of_parts = path_parts.length;
 
             if (amount_of_parts > 0){
-                if (amount_of_parts === 1){
-                    // Only one argument (fiddle_id)
-                    data.fiddle_code = path_parts[0];
-                    logIfVerbose('Detected single fiddle url..')
-                } else {
-                    // Could bee user/fiddle_id or fiddle_id/command
-                    if (isCommand(path_parts[1])){
+
+                // The url could end with a command (/show, /embed)
+                if (isCommand(path_parts[amount_of_parts - 1])){
+                    logIfVerbose('Detected url finished in a command..');
+                    amount_of_parts--;
+                }
+
+                switch (amount_of_parts){
+
+                    case 1 :  // The user may not be present on the url
                         data.fiddle_code = path_parts[0];
-                        logIfVerbose('Detected fiddle and command url..')
-                    } else {
-                        switch (amount_of_parts){
-                            case 1 : // The user may not be present on the url
-                                data.fiddle_code = path_parts[0];
-                                logIfVerbose('Detected fiddle url..');
-                                break;
-                            case 2 :
-                                // The second value could be the fiddle version
-                                if (/^\d+$/.test(path_parts[1])) {
-                                    data.fiddle_code = path_parts[0];
-                                    data.fiddle_version = path_parts[1];
-                                    logIfVerbose('Detected fiddle url and version..')
-                                } else {
-                                    // The user and the fiddle url is present
-                                    data.user = path_parts[0];
-                                    data.fiddle_code = path_parts[1];
-                                    logIfVerbose('Detected user and fiddle code..')
-                                }
-                                break;
-                            case 3  :
-                                data.user = path_parts[0];
-                                data.fiddle_code = path_parts[1];
-                                data.fiddle_version = path_parts[2];
-                                logIfVerbose('Detected user, fiddle and version..')
-                                break;
-                            default :
-                                logIfVerbose('Unrecognized url..')
-                                reject(new Error('Invalid url'));
+                        logIfVerbose('Detected fiddle url..');
+                        break;
+                    case 2 :
+                        // The second value could be the fiddle version
+                        if (/^\d+$/.test(path_parts[1])) {
+                            data.fiddle_code = path_parts[0];
+                            data.fiddle_version = path_parts[1];
+                            logIfVerbose('Detected fiddle url and version..')
+                        } else {
+                            // The user and the fiddle url is present
+                            data.user = path_parts[0];
+                            data.fiddle_code = path_parts[1];
+                            logIfVerbose('Detected user and fiddle code..')
                         }
-                    }
+                        break;
+                    case 3  :
+                        data.user = path_parts[0];
+                        data.fiddle_code = path_parts[1];
+                        data.fiddle_version = path_parts[2];
+                        logIfVerbose('Detected user, fiddle and version..')
+                        break;
+                    default :
+                        logIfVerbose('Unrecognized url..')
+                        reject(new Error('Invalid url'));
                 }
+
                 process.stdout.write('Detected fiddle code = '+chalk.green(data.fiddle_code));
-                if (data.fiddle_version != null){
+
+                if (data.fiddle_version != null)
                     process.stdout.write(', version = '+chalk.green(data.fiddle_version));
-                }
-                if (data.user != null){
+
+                if (data.user != null)
                     process.stdout.write(', from user = '+chalk.green(data.user));
-                }
+
                 process.stdout.write('\n');
                 resolve(data);
             }else{

--- a/bin/jsfiddle-downloader.js
+++ b/bin/jsfiddle-downloader.js
@@ -16,7 +16,7 @@ var fs = require("fs");
 //#############################################################################
 
 commander
-    .version('0.1.3')
+    .version('0.1.4')
     .option('-u, --user <user>', 'Save all the users fiddles')
     .option('-l, --link <url>', 'Url of the fiddle to save')
     .option('-o, --output <path>', 'Target path to download the data')
@@ -207,41 +207,48 @@ function loadDataFromUrl(url){
             var url_parts = url_parser.parse(url);
             var path_parts = url_parts.path.split('/');
 
-            if (path_parts.length > 1){
-                amount_of_parts = path_parts.length - 1; // Minus the first slash
+            // Remove the first slash
+            path_parts.shift();
 
+            // If the url finishes with a slash, it must be ignored
+            if (path_parts[path_parts.length - 1] === '')
+                path_parts.length--;
+
+            var amount_of_parts = path_parts.length;
+
+            if (amount_of_parts > 0){
                 if (amount_of_parts === 1){
                     // Only one argument (fiddle_id)
-                    data.fiddle_code = path_parts[1];
+                    data.fiddle_code = path_parts[0];
                     logIfVerbose('Detected single fiddle url..')
                 } else {
                     // Could bee user/fiddle_id or fiddle_id/command
-                    if (isCommand(path_parts[2])){
-                        data.fiddle_code = path_parts[1];
+                    if (isCommand(path_parts[1])){
+                        data.fiddle_code = path_parts[0];
                         logIfVerbose('Detected fiddle and command url..')
                     } else {
                         switch (amount_of_parts){
-                            case 2 : // The user may not be present on the url
-                                data.fiddle_code = path_parts[1];
+                            case 1 : // The user may not be present on the url
+                                data.fiddle_code = path_parts[0];
                                 logIfVerbose('Detected fiddle url..');
                                 break;
-                            case 3 :
+                            case 2 :
                                 // The second value could be the fiddle version
-                                if (/^\d+$/.test(path_parts[2])) {
-                                    data.fiddle_code = path_parts[1];
-                                    data.fiddle_version = path_parts[2];
+                                if (/^\d+$/.test(path_parts[1])) {
+                                    data.fiddle_code = path_parts[0];
+                                    data.fiddle_version = path_parts[1];
                                     logIfVerbose('Detected fiddle url and version..')
                                 } else {
                                     // The user and the fiddle url is present
-                                    data.user = path_parts[1];
-                                    data.fiddle_code = path_parts[2];
+                                    data.user = path_parts[0];
+                                    data.fiddle_code = path_parts[1];
                                     logIfVerbose('Detected user and fiddle code..')
                                 }
                                 break;
-                            case 4  :
-                                data.user = path_parts[1];
-                                data.fiddle_code = path_parts[2];
-                                data.fiddle_version = path_parts[3];
+                            case 3  :
+                                data.user = path_parts[0];
+                                data.fiddle_code = path_parts[1];
+                                data.fiddle_version = path_parts[2];
                                 logIfVerbose('Detected user, fiddle and version..')
                                 break;
                             default :

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsfiddle-downloader",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A downloader tool for jsFiddle's",
   "main": "bin/index.js",
   "bin": {


### PR DESCRIPTION
Fix for the [issue #5](https://github.com/facundovictor/jsfiddle-downloader/issues/5).

This includes:
* Support for urls ending with slash ('/')
* Support for urls ending with command **/show**
* Support for urls ending with command **/embed**
* Updated the version number output when using **--version**

The new version is **0.1.4**